### PR TITLE
Fix tests with Flink

### DIFF
--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -284,6 +284,7 @@ fun DependencyHandlerScope.icebergFlinkDependencies(configuration: String, flink
   )
   add(configuration, "org.apache.flink:flink-connector-base:${flink.flinkVersion}")
   add(configuration, "org.apache.flink:flink-connector-files:${flink.flinkVersion}")
+  add(configuration, "org.apache.flink:flink-metrics-dropwizard:${flink.flinkVersion}")
 
   add(configuration, "org.apache.flink:flink-test-utils-junit:${flink.flinkVersion}") {
     exclude("junit")


### PR DESCRIPTION
Tests began to fail with `java.lang.ClassNotFoundException: org.apache.flink.dropwizard.metrics.DropwizardHistogramWrapper`, adding `org.apache.flink:flink-metrics-dropwizard` to the dependencies fixes the issue.