### PR TITLE
Add support for Nessie 0.44

### DIFF
--- a/buildSrc/src/main/kotlin/Utilities.kt
+++ b/buildSrc/src/main/kotlin/Utilities.kt
@@ -22,6 +22,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependency
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
@@ -223,7 +224,8 @@ fun majorVersion(version: String): String {
 
 fun DependencyHandlerScope.icebergSparkDependencies(
   configuration: String,
-  sparkScala: SparkScalaVersions
+  sparkScala: SparkScalaVersions,
+  project: Project
 ) {
   add(configuration, "org.apache.iceberg:iceberg-api")
   add(configuration, "org.apache.iceberg:iceberg-nessie")
@@ -246,7 +248,14 @@ fun DependencyHandlerScope.icebergSparkDependencies(
     add(
       configuration,
       "org.projectnessie:nessie-spark-extensions-${sparkScala.sparkMajorVersion}_${sparkScala.scalaMajorVersion}"
-    )
+    ) {
+      attributes {
+        attribute(
+          Bundling.BUNDLING_ATTRIBUTE,
+          project.objects.named(Bundling::class.java, Bundling.SHADOWED)
+        )
+      }
+    }
   }
 
   add(configuration, "org.apache.spark:spark-sql_${sparkScala.scalaMajorVersion}") {

--- a/buildSrc/src/main/kotlin/tools-integrations-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools-integrations-conventions.gradle.kts
@@ -17,6 +17,7 @@
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.bundling.Jar
@@ -24,6 +25,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.api.tasks.testing.Test
 import org.gradle.external.javadoc.CoreJavadocOptions
+import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.maven
 import org.gradle.kotlin.dsl.named
@@ -63,8 +65,17 @@ configurations.all {
               req.group == "org.apache.iceberg" &&
               (req.version.isEmpty() || req.version != icebergVersionToUse)
           ) {
-            val target = "${req.group}:${req.module}:$icebergVersionToUse"
-            useTarget(target, "Managed Iceberg version to $icebergVersionToUse")
+            // TODO get rid of the internal Gradle classes DefaultImmutableVersionConstraint +
+            //  DefaultModuleComponentSelector.
+            val version = DefaultImmutableVersionConstraint.of(icebergVersionToUse)
+            val target =
+              DefaultModuleComponentSelector.newSelector(
+                req.moduleIdentifier,
+                version,
+                req.attributes,
+                req.requestedCapabilities
+              )
+            useTarget(target, "Managed Iceberg version to $version (attributes: ${req.attributes})")
           }
           if (
             nessieVersionToUse != null &&
@@ -73,8 +84,17 @@ configurations.all {
               req.module != "nessie-antlr-runtime" &&
               (req.module.startsWith("nessie") || req.module == "iceberg-views")
           ) {
-            val target = "${req.group}:${req.module}:$nessieVersionToUse"
-            useTarget(target, "Managed Nessie version to $nessieVersionToUse")
+            // TODO get rid of the internal Gradle classes DefaultImmutableVersionConstraint +
+            //  DefaultModuleComponentSelector.
+            val version = DefaultImmutableVersionConstraint.of(nessieVersionToUse)
+            val target =
+              DefaultModuleComponentSelector.newSelector(
+                req.moduleIdentifier,
+                version,
+                req.attributes,
+                req.requestedCapabilities
+              )
+            useTarget(target, "Managed Nessie version to $version (attributes: ${req.attributes})")
           }
         }
       }

--- a/nqeit-cross-engine/build.gradle.kts
+++ b/nqeit-cross-engine/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation(project(":nqeit-iceberg-spark-extension"))
   implementation(project(":nqeit-iceberg-flink-extension"))
 
-  icebergSparkDependencies("implementation", crossEngine.sparkScala)
+  icebergSparkDependencies("implementation", crossEngine.sparkScala, project)
   icebergFlinkDependencies("implementation", crossEngine.flink)
 
   testImplementation(platform(libs.junit.bom))

--- a/nqeit-iceberg-spark-extension/build.gradle.kts
+++ b/nqeit-iceberg-spark-extension/build.gradle.kts
@@ -36,5 +36,5 @@ dependencies {
   compileOnly(platform(libs.junit.bom))
   compileOnly(libs.junit.jupiter.engine)
 
-  icebergSparkDependencies("compileOnly", sparkScala)
+  icebergSparkDependencies("compileOnly", sparkScala, project)
 }

--- a/nqeit-iceberg-spark/build.gradle.kts
+++ b/nqeit-iceberg-spark/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   implementation(project(":nqeit-nessie-common"))
   implementation(project(":nqeit-iceberg-spark-extension"))
 
-  icebergSparkDependencies("implementation", sparkScala)
+  icebergSparkDependencies("implementation", sparkScala, project)
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.bundles.junit.testing)


### PR DESCRIPTION
The change ensures that the right Gradle dependency variant for the Nessie Spark Extensions is chosen, it needs to select the one having the bundling `SHADOWED`.