### PR TITLE
CI: auto-destruct spawned Nessie Quarkus runner JVM

### DIFF
--- a/buildSrc/src/main/kotlin/tools-integrations-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/tools-integrations-conventions.gradle.kts
@@ -92,6 +92,7 @@ fun Project.configureIntTests() {
           // ignore
         }
         environmentNonInput.put("HTTP_ACCESS_LOG_LEVEL", testLogLevel())
+        jvmArgumentsNonInput.add("-XX:SelfDestructTimer=30")
       }
 
       dependencies {


### PR DESCRIPTION
It can sometimes happen that the JVMs running Nessie spawned by CI linger around. This JVM settings automatically destructs thos JVMs after 30 minutes.