### PR TITLE
Allow publishing Gradle build scans from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,32 +88,32 @@ jobs:
       - name: Spotless
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: spotlessCheck
+          arguments: spotlessCheck --scan
 
       - name: Checkstyle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: checkstyleMain checkstyleTest
+          arguments: checkstyleMain checkstyleTest --scan
 
       - name: Iceberg Nessie test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :iceberg:iceberg-nessie:test
+          arguments: :iceberg:iceberg-nessie:test --scan
 
       - name: Nessie Spark 3.1 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest --scan
 
       - name: Nessie Spark 3.2 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
 
       - name: Nessie Spark 3.3 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest
+          arguments: :nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
 
       - name: Stop Gradle daemon
         uses: gradle/gradle-build-action@v2
@@ -123,7 +123,7 @@ jobs:
       - name: Publish Nessie + Iceberg to local Maven repo
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publishLocal
+          arguments: publishLocal --scan
 
       - name: Gather locally published versions
         run: |
@@ -151,7 +151,7 @@ jobs:
       - name: Tools & Integrations tests / Scala 2.12
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -DscalaVersion=2.12
+          arguments: intTest -DscalaVersion=2.12 --scan
 
       - name: Show Gradle projects for Scala 2.13
         uses: gradle/gradle-build-action@v2
@@ -161,7 +161,7 @@ jobs:
       - name: Tools & Integrations tests / Scala 2.13
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -DscalaVersion=2.13
+          arguments: intTest -DscalaVersion=2.13 --scan
 
       #- name: Checkout Presto repo
       #  uses: actions/checkout@v3
@@ -222,7 +222,7 @@ jobs:
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.44.0 -Dnessie.versionIceberg=1.1.0
+          arguments: intTest -Dnessie.versionNessie=0.44.0 -Dnessie.versionIceberg=1.1.0 --scan
 
   iceberg10_nessie043:
     name: Nessie 0.43 / Iceberg 1.0
@@ -255,7 +255,7 @@ jobs:
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.43.0 -Dnessie.versionIceberg=1.0.0
+          arguments: intTest -Dnessie.versionNessie=0.43.0 -Dnessie.versionIceberg=1.0.0 --scan
 
   iceberg10_nessie030:
     name: Nessie 0.30 / Iceberg 1.0
@@ -288,7 +288,7 @@ jobs:
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.30.0 -Dnessie.versionIceberg=1.0.0
+          arguments: intTest -Dnessie.versionNessie=0.30.0 -Dnessie.versionIceberg=1.0.0 --scan
 
   iceberg014_nessie041:
     name: Nessie 0.41 / Iceberg 0.14

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,44 @@ pluginManagement {
   }
 }
 
+plugins { id("com.gradle.enterprise") version ("3.12") }
+
+gradleEnterprise {
+  if (System.getenv("CI") != null) {
+    buildScan {
+      termsOfServiceUrl = "https://gradle.com/terms-of-service"
+      termsOfServiceAgree = "yes"
+      // Add some potentially interesting information from the environment
+      listOf(
+          "GITHUB_ACTION_REPOSITORY",
+          "GITHUB_ACTOR",
+          "GITHUB_BASE_REF",
+          "GITHUB_HEAD_REF",
+          "GITHUB_JOB",
+          "GITHUB_REF",
+          "GITHUB_REPOSITORY",
+          "GITHUB_RUN_ID",
+          "GITHUB_RUN_NUMBER",
+          "GITHUB_SHA",
+          "GITHUB_WORKFLOW"
+        )
+        .forEach { e ->
+          val v = System.getenv(e)
+          if (v != null) {
+            value(e, v)
+          }
+        }
+      val ghUrl = System.getenv("GITHUB_SERVER_URL")
+      if (ghUrl != null) {
+        val ghRepo = System.getenv("GITHUB_REPOSITORY")
+        val ghRunId = System.getenv("GITHUB_RUN_ID")
+        link("Summary", "$ghUrl/$ghRepo/actions/runs/$ghRunId")
+        link("PRs", "$ghUrl/$ghRepo/pulls")
+      }
+    }
+  }
+}
+
 gradle.beforeProject {
   version = baseVersion
   group = "org.projectnessie.integrations-tools-tests"


### PR DESCRIPTION
But not automatically for every build to protect sensitve workflows, like releasw workflows that have access to sensitive secrets. Gradle build scans are available for free (Gradle Enterprise is not required). The scans help identifying build issues, dependency issues, build performance issues. Also interesting: it shows the result of each test of a CI run.

Build scans are not published for every run - especially sensitive workflows (release workflows w/ access to secrets) are not scanned/published.

Links to the build scans are available from the Summary page of the workflow runs.