### PR TITLE
Revert "Temporary workaround for Iceberg source builds (#134)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,8 @@ jobs:
       ICEBERG_DIR: included-builds/iceberg
       ICEBERG_MAIN_REPOSITORY: apache/iceberg
       ICEBERG_MAIN_BRANCH: master
-      # TODO revert the change in the following two lines once https://github.com/apache/iceberg/pull/6649 has been merged
-      ICEBERG_PATCH_REPOSITORY: snazy/iceberg
-      ICEBERG_PATCH_BRANCH: nessie-dep-nit
+      ICEBERG_PATCH_REPOSITORY: ''
+      ICEBERG_PATCH_BRANCH: ''
       SPARK_LOCAL_IP: localhost
 
     steps:


### PR DESCRIPTION
This reverts commit 75a67ac5518da58dab35dc773a8a732c23bb68f0.