### PR TITLE
Bump Presto versions + adopt Flink versions

### DIFF
--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -29,7 +29,7 @@ sparkVersion-3.3-scalaVersions=2.12,2.13
 # Exact Spark versions by major version
 versionSpark-3.1=3.1.3
 versionSpark-3.2=3.2.3
-versionSpark-3.3=3.3.1
+versionSpark-3.3=3.3.2
 
 # Known Scala major versions
 scalaVersions=2.12,2.13
@@ -43,31 +43,35 @@ versionScala-2.13=2.13.10
 # Flink versions
 
 # Known Flink major versions
-flinkVersions=1.14,1.15,1.16
-flinkDefaultVersion=1.14
+flinkVersions=1.14,1.15,1.16,1,17
+flinkDefaultVersion=1.15
 # Exact flink version by major version
 versionFlink-1.14=1.14.6
-versionFlink-1.15=1.15.3
+versionFlink-1.15=1.15.4
 versionFlink-1.16=1.16.1
+versionFlink-1.17=1.17.0
 # hadoop version for Flink (some Hadoop dependencies required by Flink)
 versionFlinkHadoop-1.14=2.7.3
 versionFlinkHadoop-1.15=2.7.3
 versionFlinkHadoop-1.16=2.7.3
+versionFlinkHadoop-1.17=2.7.3
 # Scala versions for Flink, not really using Scala for Flink, but some Java dependencies have Scala
 # version numbers in their artifact-ID.
 flink-scala-1.14=2.12
 flink-scala-1.15=2.12
 flink-scala-1.16=2.12
+flink-scala-1.17=2.12
 flink-scalaForDependencies-1.14=_2.12
 flink-scalaForDependencies-1.15=
 flink-scalaForDependencies-1.16=
+flink-scalaForDependencies-1.17=
 
 #
 # Flink versions
 
 # Known Presto major versions
-prestoVersions=0.274,0.275,0.276,0.277,0.278
-prestoDefaultVersion=0.278
+prestoVersions=0.274,0.275,0.276,0.277,0.278,0.279,0.280
+prestoDefaultVersion=0.280
 
 # Exact Presto versions by Presto major versions
 versionPresto-0.274=0.274
@@ -75,11 +79,13 @@ versionPresto-0.275=0.275
 versionPresto-0.276=0.276.2
 versionPresto-0.277=0.277
 versionPresto-0.278=0.278.1
+versionPresto-0.279=0.279
+versionPresto-0.280=0.280
 
 #
 # Define the Cross-Engine setups
 
-crossEngineSetups=spark32flink114,spark33flink115,spark33flink116
+crossEngineSetups=spark32flink114,spark33flink115,spark33flink116,spark33flink117
 
 crossEngine.spark32flink114.sparkMajorVersion=3.2
 crossEngine.spark32flink114.scalaMajorVersion=2.12
@@ -92,6 +98,10 @@ crossEngine.spark33flink115.flinkMajorVersion=1.15
 crossEngine.spark33flink116.sparkMajorVersion=3.3
 crossEngine.spark33flink116.scalaMajorVersion=2.12
 crossEngine.spark33flink116.flinkMajorVersion=1.16
+
+crossEngine.spark33flink117.sparkMajorVersion=3.3
+crossEngine.spark33flink117.scalaMajorVersion=2.12
+crossEngine.spark33flink117.flinkMajorVersion=1.17
 
 
 #
@@ -113,11 +123,13 @@ constraints.flinkVersions.iceberg-0.13=1.14
 constraints.flinkVersions.iceberg-0.14=1.14,1.15
 constraints.flinkVersions.iceberg-1.0=1.14,1.15
 constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16
-constraints.flinkVersions.iceberg-999.99=1.14,1.15,1.16
+constraints.flinkVersions.iceberg-1.2=1.14,1.15,1.16
+constraints.flinkVersions.iceberg-999.99=1.15,1.16,1.17
 # Presto version restrictions - for specific Iceberg versions
 constraints.prestoVersions.iceberg-0.13=0.274,0.275
 constraints.prestoVersions.iceberg-0.14=0.277
 constraints.prestoVersions.iceberg-1.0=0.277
 constraints.prestoVersions.iceberg-1.1=0.278
+constraints.prestoVersions.iceberg-1.2=0.280
 # Presto version supporting current "main branch" Iceberg
-constraints.prestoVersions.iceberg-999.99=0.278
+constraints.prestoVersions.iceberg-999.99=0.280

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,4 +44,4 @@ systemProp.scalaVersion=2.12
 
 # System property to tell the included Iceberg build which Flink versions to build for.
 # This is a system property evaluated by the Iceberg build
-systemProp.flinkVersions=1.14,1.15,1.16
+systemProp.flinkVersions=1.15,1.16,1.17


### PR DESCRIPTION
* Remove Flink 1.14 for Iceberg/master
* Add Flink 1.17 for Iceberg/master
* Set Flink default to 1.15
* Add combinations for Iceberg 1.2
* Add Presto 0.280
+ Bump Spark from 3.3.1 to 3.3.2