### PR TITLE
Remove old versions & bump versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,8 +199,8 @@ jobs:
       #      -Ddep.iceberg.version=${ICEBERG_VERSION} \
       #      -Ddep.nessie.version=${NESSIE_VERSION}
 
-  iceberg121_nessie058:
-    name: Nessie 0.58 / Iceberg 1.2.1
+  iceberg121_nessie0601:
+    name: Nessie 0.60.1 / Iceberg 1.2.1
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
@@ -225,75 +225,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
-          arguments: projects -Dnessie.versionNessie=0.58.0 -Dnessie.versionIceberg=1.2.1
+          arguments: projects -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.2.1
 
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.58.0 -Dnessie.versionIceberg=1.2.1 --scan
+          arguments: intTest -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.2.1 --scan
 
-  iceberg11_nessie044:
-    name: Nessie 0.44 / Iceberg 1.1
-    runs-on: ubuntu-latest
-    env:
-      SPARK_LOCAL_IP: localhost
-
-    steps:
-      - name: Checkout Integrations Testing repo
-        uses: actions/checkout@v3
-
-      - name: Setup gradle.properties
-        run: |
-          mkdir -p ~/.gradle
-          echo "org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
-          echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties
-
-      - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Show Gradle projects
-        uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: true
-          arguments: projects -Dnessie.versionNessie=0.44.0 -Dnessie.versionIceberg=1.1.0
-
-      - name: Tools & Integrations tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: intTest -Dnessie.versionNessie=0.44.0 -Dnessie.versionIceberg=1.1.0 --scan
-
-  iceberg10_nessie043:
-    name: Nessie 0.43 / Iceberg 1.0
-    runs-on: ubuntu-latest
-    env:
-      SPARK_LOCAL_IP: localhost
-
-    steps:
-      - name: Checkout Integrations Testing repo
-        uses: actions/checkout@v3
-
-      - name: Setup gradle.properties
-        run: |
-          mkdir -p ~/.gradle
-          echo "org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=768m -Dfile.encoding=UTF-8" >> ~/.gradle/gradle.properties
-          echo "org.gradle.vfs.watch=false" >> ~/.gradle/gradle.properties
-
-      - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Show Gradle projects
-        uses: gradle/gradle-build-action@v2
-        with:
-          cache-read-only: true
-          arguments: projects -Dnessie.versionNessie=0.43.0 -Dnessie.versionIceberg=1.0.0
-
-      - name: Tools & Integrations tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: intTest -Dnessie.versionNessie=0.43.0 -Dnessie.versionIceberg=1.0.0 --scan

--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -28,7 +28,7 @@ sparkVersion-3.3-scalaVersions=2.12,2.13
 
 # Exact Spark versions by major version
 versionSpark-3.1=3.1.3
-versionSpark-3.2=3.2.3
+versionSpark-3.2=3.2.4
 versionSpark-3.3=3.3.2
 
 # Known Scala major versions
@@ -70,8 +70,8 @@ flink-scalaForDependencies-1.17=
 # Flink versions
 
 # Known Presto major versions
-prestoVersions=0.274,0.275,0.276,0.277,0.278,0.279,0.280
-prestoDefaultVersion=0.280
+prestoVersions=0.274,0.275,0.276,0.277,0.278,0.279,0.280,0.281
+prestoDefaultVersion=0.281
 
 # Exact Presto versions by Presto major versions
 versionPresto-0.274=0.274
@@ -81,6 +81,7 @@ versionPresto-0.277=0.277
 versionPresto-0.278=0.278.1
 versionPresto-0.279=0.279
 versionPresto-0.280=0.280
+versionPresto-0.281=0.281
 
 #
 # Define the Cross-Engine setups
@@ -109,27 +110,17 @@ crossEngine.spark33flink117.flinkMajorVersion=1.17
 # This helps modelling the produced Gradle projects depending on the versions of e.g. Nessie or
 # Iceberg being used.
 
-# Scala version restrictions - for specific Nessie versions
-constraints.scalaVersions.nessie-0.30=2.12
-# Scala version restrictions - for specific Iceberg versions
-constraints.scalaVersions.iceberg-0.13=2.12
-# Spark version restrictions - for specific Nessie versions
-constraints.sparkVersions.nessie-0.30=3.2
 # TODO constraints.sparkVersions.nessie-0.30=3.1,3.2 --> there are issues w/ Spark 3.1
 # Spark version restrictions - for specific Iceberg versions
 constraints.sparkVersions.iceberg-0.13=3.1,3.2
 # Flink version restrictions - for specific Iceberg versions
-constraints.flinkVersions.iceberg-0.13=1.14
-constraints.flinkVersions.iceberg-0.14=1.14,1.15
 constraints.flinkVersions.iceberg-1.0=1.14,1.15
 constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-1.2=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-999.99=1.15,1.16,1.17
 # Presto version restrictions - for specific Iceberg versions
-constraints.prestoVersions.iceberg-0.13=0.274,0.275
-constraints.prestoVersions.iceberg-0.14=0.277
 constraints.prestoVersions.iceberg-1.0=0.277
 constraints.prestoVersions.iceberg-1.1=0.278
-constraints.prestoVersions.iceberg-1.2=0.280
+constraints.prestoVersions.iceberg-1.2=0.281
 # Presto version supporting current "main branch" Iceberg
-constraints.prestoVersions.iceberg-999.99=0.280
+constraints.prestoVersions.iceberg-999.99=0.281


### PR DESCRIPTION
* Removes CI jobs for old Nessie and Iceberg versions
* Bump Spark patch version
* Use recent Presto