### PR TITLE
Bump CI version combinations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,8 +199,8 @@ jobs:
       #      -Ddep.iceberg.version=${ICEBERG_VERSION} \
       #      -Ddep.nessie.version=${NESSIE_VERSION}
 
-  iceberg130_nessie0601:
-    name: Nessie 0.60.1 / Iceberg 1.3.0
+  iceberg131_nessie0651:
+    name: Nessie 0.65.1 / Iceberg 1.3.1
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
@@ -225,15 +225,15 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
-          arguments: projects -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.3.0
+          arguments: projects -Dnessie.versionNessie=0.65.1 -Dnessie.versionIceberg=1.3.1
 
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.3.0 --scan
+          arguments: intTest -Dnessie.versionNessie=0.65.1 -Dnessie.versionIceberg=1.3.1 --scan
 
-  iceberg121_nessie0601:
-    name: Nessie 0.60.1 / Iceberg 1.2.1
+  iceberg131_nessie0601:
+    name: Nessie 0.60.1 / Iceberg 1.3.1
     runs-on: ubuntu-latest
     env:
       SPARK_LOCAL_IP: localhost
@@ -258,10 +258,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           cache-read-only: true
-          arguments: projects -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.2.1
+          arguments: projects -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.3.1
 
       - name: Tools & Integrations tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: intTest -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.2.1 --scan
+          arguments: intTest -Dnessie.versionNessie=0.60.1 -Dnessie.versionIceberg=1.3.1 --scan
 


### PR DESCRIPTION
* Nessie 0.60.1/Iceberg 1.3.0 -> Nessie 0.65.1/Iceberg 1.3.1
* Nessie 0.60.1/Iceberg 1.2.1 -> Nessie 0.60.1/Iceberg 1.3.1