### PR TITLE
Remove Spark 3.1 for Iceberg 1.4+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,11 +108,6 @@ jobs:
         with:
           arguments: :iceberg:iceberg-nessie:test --scan
 
-      - name: Nessie Spark 3.1 Extensions test
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.1_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.1_2.12:intTest --scan
-
       - name: Nessie Spark 3.2 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:
@@ -122,6 +117,11 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.3_2.12:intTest --scan
+
+      - name: Nessie Spark 3.4 / 2.12 Extensions test
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.12:intTest --scan
 
       - name: Build before publish
         uses: gradle/gradle-build-action@v2

--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -130,6 +130,7 @@ constraints.sparkVersions.nessie-0.60=3.1,3.2,3.3
 constraints.sparkVersions.iceberg-1.1=3.1,3.2,3.3
 constraints.sparkVersions.iceberg-1.2=3.1,3.2,3.3
 constraints.sparkVersions.iceberg-1.3=3.1,3.2,3.3,3.4
+constraints.sparkVersions.iceberg-999.99=3.2,3.3,3.4
 # Flink version restrictions - for specific Iceberg versions
 constraints.flinkVersions.iceberg-1.0=1.14,1.15
 constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ org.gradle.vfs.watch=false
 # System property to tell the included Iceberg build the Spark versions to build for
 # (required for :clients:spark-31-extensions). This is a system property evaluated by the Iceberg
 # build
-systemProp.sparkVersions=3.1,3.2,3.3,3.4
+systemProp.sparkVersions=3.2,3.3,3.4,3.5
 systemProp.scalaVersion=2.12
 
 # System property to tell the included Iceberg build which Flink versions to build for.


### PR DESCRIPTION
Spark 3.1 has been removed in Iceberg 1.4