### PR TITLE
renovate: reduce awssdk update frequency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,14 @@
       matchManagers: ["maven", "gradle", "gradle-wrapper"],
       matchUpdateTypes: ["major"],
       automerge: false
-    }
+    },
+
+    // Reduce awssdk update frequency (which has daily releases)
+    {
+      matchManagers: ["maven", "gradle"],
+      matchPackageNames: ["software.amazon.awssdk:*"],
+      extends: ["schedule:weekly"],
+    },
   ],
 
   // Max 50 PRs in total, 10 per hour


### PR DESCRIPTION
its just too much in terms of commits and waste of CI resources:
```
➜  query-engine-integration-tests git:(renovate-awssdk) ✗ git log --oneline | wc -l
458
➜  query-engine-integration-tests git:(renovate-awssdk) ✗ git log --oneline | grep "Update.*aws" | wc -l
240
```
also most (all?) of CI doesnt even use awssdk