### PR TITLE
iceberg master removed flink 1.15

### DIFF
--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -48,7 +48,7 @@ versionScala-2.13=2.13.12
 
 # Known Flink major versions
 flinkVersions=1.14,1.15,1.16,1.17
-flinkDefaultVersion=1.15
+flinkDefaultVersion=1.16
 # Exact flink version by major version
 versionFlink-1.14=1.14.6
 versionFlink-1.15=1.15.4
@@ -150,7 +150,7 @@ constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-1.2=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-1.3=1.15,1.16,1.17
 constraints.flinkVersions.iceberg-1.4=1.15,1.16,1.17
-constraints.flinkVersions.iceberg-999.99=1.15,1.16,1.17
+constraints.flinkVersions.iceberg-999.99=1.16,1.17
 # Presto version restrictions - for specific Iceberg versions
 constraints.prestoVersions.iceberg-1.0=0.277
 constraints.prestoVersions.iceberg-1.1=0.278

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,4 +41,4 @@ systemProp.scalaVersion=2.12
 
 # System property to tell the included Iceberg build which Flink versions to build for.
 # This is a system property evaluated by the Iceberg build
-systemProp.flinkVersions=1.15,1.16,1.17
+systemProp.flinkVersions=1.16,1.17

--- a/nqeit-iceberg-flink-extension/build.gradle.kts
+++ b/nqeit-iceberg-flink-extension/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
   compileOnly(libs.jetbrains.annotations)
   compileOnly(libs.errorprone.annotations)
 
+  compileOnly(libs.guava)
+
   compileOnly(platform(libs.junit.bom))
   compileOnly(libs.junit.jupiter.engine)
 

--- a/nqeit-presto-extension/build.gradle.kts
+++ b/nqeit-presto-extension/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
   compileOnly(libs.microprofile.openapi)
   compileOnly(libs.jetbrains.annotations)
 
+  compileOnly(libs.guava)
+
   compileOnly(platform(libs.junit.bom))
   compileOnly(libs.junit.jupiter.engine)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -370,7 +370,7 @@ if (includeIcebergBuild) {
           }
         }
       }
-      System.getProperty("flinkVersions", "1.15").split(",").forEach { flinkVersion ->
+      System.getProperty("flinkVersions", "1.16").split(",").forEach { flinkVersion ->
         substitute(module("org.apache.iceberg:iceberg-flink-$flinkVersion"))
           .using(project(":iceberg-flink:iceberg-flink-$flinkVersion"))
         substitute(module("org.apache.iceberg:iceberg-flink-runtime-$flinkVersion"))


### PR DESCRIPTION
see https://github.com/apache/iceberg/commit/274390f3d65d9f48b26e3c682225d6f9edb35bce

also update defaults to 1.16

this fixes our failing CI:
```
FAILURE: Build failed with an exception.

* Where:
Settings file '/home/runner/work/query-engine-integration-tests/query-engine-integration-tests/included-builds/iceberg/settings.gradle' line: 78

* What went wrong:
A problem occurred evaluating settings 'iceberg'.
> Found unsupported Flink versions: [1.15]
```