### PR TITLE
renovate: fix awssdk matcher

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
     // Reduce awssdk update frequency (which has daily releases)
     {
       matchManagers: ["maven", "gradle"],
-      matchPackageNames: ["software.amazon.awssdk:*"],
+      matchPackagePrefixes: ["software.amazon.awssdk"],
       extends: ["schedule:weekly"],
     },
   ],


### PR DESCRIPTION
https://github.com/projectnessie/query-engine-integration-tests/pull/485 did not work:

https://github.com/projectnessie/query-engine-integration-tests/pull/489
https://github.com/projectnessie/query-engine-integration-tests/pull/491
https://github.com/projectnessie/query-engine-integration-tests/pull/496
were not 1 week apart each

lets try using [matchPackagePrefixes](https://github.com/renovatebot/renovate/blob/main/docs/usage/configuration-options.md#matchpackageprefixes) instead
it should work because of:

> For Maven dependencies, the package name is <groupId:artefactId>, e.g. "matchPackageNames": ["com.thoughtworks.xstream:xstream"]

https://github.com/renovatebot/renovate/blob/main/docs/usage/configuration-options.md#packagerules