### PR TITLE
iceberg master removed spark 3.2

### DIFF
--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -19,7 +19,7 @@
 
 # Known Spark major version
 sparkVersions=3.1,3.2,3.3,3.4,3.5
-sparkDefaultVersion=3.2
+sparkDefaultVersion=3.3
 
 # Supported Scala major versions, by Spark major version
 sparkVersion-3.1-scalaVersions=2.12
@@ -143,7 +143,7 @@ constraints.sparkVersions.iceberg-1.1=3.1,3.2,3.3
 constraints.sparkVersions.iceberg-1.2=3.1,3.2,3.3
 constraints.sparkVersions.iceberg-1.3=3.1,3.2,3.3,3.4
 constraints.sparkVersions.iceberg-1.4=3.2,3.3,3.4,3.5
-constraints.sparkVersions.iceberg-999.99=3.2,3.3,3.4,3.5
+constraints.sparkVersions.iceberg-999.99=3.3,3.4,3.5
 # Flink version restrictions - for specific Iceberg versions
 constraints.flinkVersions.iceberg-1.0=1.14,1.15
 constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ org.gradle.vfs.watch=false
 # System property to tell the included Iceberg build the Spark versions to build for
 # (required for :clients:spark-31-extensions). This is a system property evaluated by the Iceberg
 # build
-systemProp.sparkVersions=3.2,3.3,3.4,3.5
+systemProp.sparkVersions=3.3,3.4,3.5
 systemProp.scalaVersion=2.12
 
 # System property to tell the included Iceberg build which Flink versions to build for.


### PR DESCRIPTION
see https://github.com/apache/iceberg/commit/c6bbbdbc11d42713c86dd52185f577b81d946963

fixes failing CI:
```
FAILURE: Build failed with an exception.

* Where:
Settings file '/home/runner/work/nessie/nessie/included-builds/iceberg/settings.gradle' line: 94

* What went wrong:
A problem occurred evaluating settings 'iceberg'.
> Found unsupported Spark versions: [3.2]
```