### PR TITLE
stop testing spark-extensions 3.2 on iceberg main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,11 +111,6 @@ jobs:
         with:
           arguments: :iceberg:iceberg-nessie:test --scan
 
-      - name: Nessie Spark 3.2 / 2.12 Extensions test
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest --scan
-
       - name: Nessie Spark 3.3 / 2.12 Extensions test
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
follow-up to https://github.com/projectnessie/query-engine-integration-tests/pull/498

which somehow fixed CI on this repo but not when run from nessie repo
(see [comment](https://github.com/projectnessie/query-engine-integration-tests/pull/498#issuecomment-1856372475))

```
> Task :nessie:nessie-iceberg:nessie-spark-extensions-3.2_2.12:intTest

ITNessieStatements > testCompaction(String, String) > [1] branchName=testCompaction, tableName=tbl FAILED
    java.lang.NoClassDefFoundError at SparkActions.java:72
        Caused by: java.lang.ClassNotFoundException at BuiltinClassLoader.java:581
```
https://github.com/projectnessie/nessie/actions/runs/7213024807/job/19652182836