### PR TITLE
fix free-disk-space action

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -28,8 +28,6 @@ runs:
           node:16-alpine \
           node:18 \
           node:18-alpine \
-          buildpack-deps:buster \
-          buildpack-deps:bullseye \
           moby/buildkit:latest \
           alpine:3.16 \
           alpine:3.17 \


### PR DESCRIPTION
the buildpack-deps images have been removed from the runners: https://github.com/actions/runner-images/pull/9093

so we no longer need to clear them up
(the command was failing any workflow that uses the action)

```
Error response from daemon: No such image: buildpack-deps:buster
Error response from daemon: No such image: buildpack-deps:bullseye
```