### PR TITLE
Bump Flink, Spark, Scala, Presto

### DIFF
--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -31,44 +31,48 @@ sparkVersion-3.5-scalaVersions=2.12,2.13
 # Exact Spark versions by major version
 versionSpark-3.1=3.1.3
 versionSpark-3.2=3.2.4
-versionSpark-3.3=3.3.3
-versionSpark-3.4=3.4.1
-versionSpark-3.5=3.5.0
+versionSpark-3.3=3.3.4
+versionSpark-3.4=3.4.2
+versionSpark-3.5=3.5.1
 
 # Known Scala major versions
 scalaVersions=2.12,2.13
 scalaDefaultVersion=2.12
 
 # Exact Scala versions by major version
-versionScala-2.12=2.12.18
-versionScala-2.13=2.13.12
+versionScala-2.12=2.12.19
+versionScala-2.13=2.13.13
 
 #
 # Flink versions
 
 # Known Flink major versions
-flinkVersions=1.14,1.15,1.16,1.17
+flinkVersions=1.14,1.15,1.16,1.17,1.18
 flinkDefaultVersion=1.16
 # Exact flink version by major version
 versionFlink-1.14=1.14.6
 versionFlink-1.15=1.15.4
-versionFlink-1.16=1.16.2
-versionFlink-1.17=1.17.1
+versionFlink-1.16=1.16.3
+versionFlink-1.17=1.17.2
+versionFlink-1.18=1.18.1
 # hadoop version for Flink (some Hadoop dependencies required by Flink)
 versionFlinkHadoop-1.14=2.7.3
 versionFlinkHadoop-1.15=2.7.3
 versionFlinkHadoop-1.16=2.7.3
 versionFlinkHadoop-1.17=2.7.3
+versionFlinkHadoop-1.18=2.7.3
 # Scala versions for Flink, not really using Scala for Flink, but some Java dependencies have Scala
 # version numbers in their artifact-ID.
 flink-scala-1.14=2.12
 flink-scala-1.15=2.12
 flink-scala-1.16=2.12
 flink-scala-1.17=2.12
+flink-scala-1.18=2.12
 flink-scalaForDependencies-1.14=_2.12
 flink-scalaForDependencies-1.15=
 flink-scalaForDependencies-1.16=
 flink-scalaForDependencies-1.17=
+flink-scalaForDependencies-1.18=
 
 #
 # Flink versions
@@ -90,7 +94,7 @@ versionPresto-0.281=0.281
 #
 # Define the Cross-Engine setups
 
-crossEngineSetups=spark32flink114,spark33flink115,spark33flink116,spark33flink117
+crossEngineSetups=spark32flink114,spark33flink115,spark33flink116,spark33flink117,spark33flink118
 # TODO ideally we'd like to run Spark 3.4 with Flink 1.17, but that does not work, because there's
 #  some awful dependency issue with `org.codehaus.janino.InternalCompilerException` coming from
 #  org.codehaus.janino:janino (Flink 1.17.x) vs org.codehaus.janino:commons-compiler (Spark 3.4),
@@ -127,6 +131,10 @@ crossEngine.spark35flink117.sparkMajorVersion=3.5
 crossEngine.spark35flink117.scalaMajorVersion=2.12
 crossEngine.spark35flink117.flinkMajorVersion=1.17
 
+crossEngine.spark33flink118.sparkMajorVersion=3.5
+crossEngine.spark33flink118.scalaMajorVersion=2.12
+crossEngine.spark33flink118.flinkMajorVersion=1.18
+
 #
 # Following properties define a bunch of major-version restrictions.
 # This helps modelling the produced Gradle projects depending on the versions of e.g. Nessie or
@@ -150,12 +158,14 @@ constraints.flinkVersions.iceberg-1.1=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-1.2=1.14,1.15,1.16
 constraints.flinkVersions.iceberg-1.3=1.15,1.16,1.17
 constraints.flinkVersions.iceberg-1.4=1.15,1.16,1.17
-constraints.flinkVersions.iceberg-999.99=1.16,1.17
+constraints.flinkVersions.iceberg-1.5=1.16,1.17,1.18
+constraints.flinkVersions.iceberg-999.99=1.16,1.17,1.18
 # Presto version restrictions - for specific Iceberg versions
 constraints.prestoVersions.iceberg-1.0=0.277
 constraints.prestoVersions.iceberg-1.1=0.278
 constraints.prestoVersions.iceberg-1.2=0.281
 constraints.prestoVersions.iceberg-1.3=0.281
 constraints.prestoVersions.iceberg-1.4=0.281
+constraints.prestoVersions.iceberg-1.5=0.281
 # Presto version supporting current "main branch" Iceberg
 constraints.prestoVersions.iceberg-999.99=0.281

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,4 +41,4 @@ systemProp.scalaVersion=2.12
 
 # System property to tell the included Iceberg build which Flink versions to build for.
 # This is a system property evaluated by the Iceberg build
-systemProp.flinkVersions=1.16,1.17
+systemProp.flinkVersions=1.16,1.17,1.18


### PR DESCRIPTION
* Spark 3.3 to 3.3.4
* Spark 3.4 to 3.4.2
* Spark 3.5 to 3.5.1
* Scala 2.12 to 2.12.19
* Scala 2.13 to 2.13.13
* Add Flink 1.18 for Iceberg 1.5 + "main"
* Bump Flink 1.16 to 1.16.3
* Bump Flink 1.17 to 1.17.2