### PR TITLE
Fix Parquet version mismatch between Iceberg and Presto

### DIFF
--- a/frameworks-versions.properties
+++ b/frameworks-versions.properties
@@ -190,4 +190,5 @@ constraints.prestoVersions.iceberg-1.4=0.281
 constraints.prestoVersions.iceberg-1.5=0.281
 constraints.prestoVersions.iceberg-1.6=0.281
 # Presto version supporting current "main branch" Iceberg
-constraints.prestoVersions.iceberg-999.99=0.281
+# '-' means no Presto
+constraints.prestoVersions.iceberg-999.99=-


### PR DESCRIPTION
Presto comes with an uber-jar containing the Parquet classes (Parquet 1.12.0 for Presto 0.281, 1.13.1 for newer Presto versions). Iceberg however expects Parquet 1.14.x. This leads to an incompatible combination of Parquet classes on the classpath, which breaks NesQuEIT's Presto tests.

The duplicate classes are in `com.facebook.presto.hive:hive-apache`. Just exluding that module doesn't immediately help, because it contains more classes, which are required by Presto. Better wait until there's a Presto release that supports recent Iceberg/Parquet.

This workaround disabled the Preto tests for current in-development Iceberg versions.