### PR TITLE
Fix NesQuEIT to pass against recent Iceberg changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,8 +119,11 @@ jobs:
       - name: Nessie Spark 3.4 / 2.12 Extensions test
         run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.4_2.13:intTest --scan
 
-      - name: Nessie Spark 3.5 / 2.13 Extensions test
-        run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
+      - name: Nessie Spark 3.5 / 2.12 Extensions test
+        run: ./gradlew -DscalaVersion=2.12 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.12:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.12:intTest --scan
+      # TODO Revert the change to Scala 2.12 after we have an Iceberg release with https://github.com/apache/iceberg/pull/11520 (Iceberg 1.8 probably)
+      #- name: Nessie Spark 3.5 / 2.13 Extensions test
+      #  run: ./gradlew -DscalaVersion=2.13 :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:test :nessie:nessie-iceberg:nessie-spark-extensions-3.5_2.13:intTest --scan
 
       - name: Build before publish
         run: ./gradlew jar testClasses javadoc --scan


### PR DESCRIPTION
Workaround for https://github.com/apache/iceberg/pull/11520 that caused a class-path issue w/ Scala 2.13